### PR TITLE
Adding caching logic for Team/Roster endpoints

### DIFF
--- a/sportsref_nfl/cache.py
+++ b/sportsref_nfl/cache.py
@@ -87,6 +87,22 @@ class NFLCache:
                 pass
             return "live_season"
 
+        elif "teams/" in endpoint:
+            # Team pages (e.g., teams/den/2019.htm or teams/den/2019_roster.htm)
+            parts = endpoint.split("/")
+            if len(parts) >= 3:
+                filename = parts[-1]  # e.g., "2019.htm" or "2019_roster.htm"
+                year_part = filename.split(".")[0].split("_")[0]  # Extract year part
+                try:
+                    team_year = int(year_part)
+                    if team_year < current_year:
+                        return "historical"
+                    else:
+                        return "current_season"
+                except ValueError:
+                    pass
+            return "current_season"
+
         elif "draft" in endpoint:
             return "draft"
         elif "stadiums" in endpoint:


### PR DESCRIPTION
## Description
- I forgot to put in caching logic for Team/Roster endpoints, it was only put in place for game/season results
- Added some logic to properly cache previous seasons' team/roster data as "historical" so it doesn't get refreshed, but keep the current season data as "current_season" to make sure it's appropriately refreshed everyday.

## Testing
- Tested locally, identifies historical vs. current rosters accurately.