### PR TITLE
Fixing Wikipedia pull and future warning

### DIFF
--- a/sportsref_nfl/core/schedule.py
+++ b/sportsref_nfl/core/schedule.py
@@ -111,7 +111,9 @@ class Schedule:
                 )
                 season_sched[["yards_win", "to_win", "yards_lose", "to_lose"]] = None
             if not season_sched.empty:
-                self.schedule = pd.concat([self.schedule, season_sched], ignore_index=True)
+                self.schedule = pd.concat(
+                    [self.schedule, season_sched], ignore_index=True
+                )
 
     def add_weeks(self) -> None:
         """

--- a/sportsref_nfl/core/schedule.py
+++ b/sportsref_nfl/core/schedule.py
@@ -110,7 +110,8 @@ class Schedule:
                     }
                 )
                 season_sched[["yards_win", "to_win", "yards_lose", "to_lose"]] = None
-            self.schedule = pd.concat([self.schedule, season_sched], ignore_index=True)
+            if not season_sched.empty:
+                self.schedule = pd.concat([self.schedule, season_sched], ignore_index=True)
 
     def add_weeks(self) -> None:
         """

--- a/sportsref_nfl/data/stadiums.py
+++ b/sportsref_nfl/data/stadiums.py
@@ -25,11 +25,10 @@ def get_intl_games() -> pd.DataFrame:
     """
     # Setting a proper User-Agent header to respect Wikipedia's robot policy
     headers = {
-        'User-Agent': 'sportsref-nfl/0.1.2 (https://github.com/tefirman/sportsref-nfl; tefirman@gmail.com)'
+        "User-Agent": "sportsref-nfl/0.1.2 (https://github.com/tefirman/sportsref-nfl; tefirman@gmail.com)"
     }
     response = requests.get(
-        "https://en.wikipedia.org/wiki/NFL_International_Series",
-        headers=headers
+        "https://en.wikipedia.org/wiki/NFL_International_Series", headers=headers
     ).text
     soup = BeautifulSoup(response, "html.parser")
     tables = soup.find_all("table", attrs={"class": "wikitable sortable"})[1:-1]

--- a/sportsref_nfl/data/stadiums.py
+++ b/sportsref_nfl/data/stadiums.py
@@ -23,8 +23,13 @@ def get_intl_games() -> pd.DataFrame:
     Returns:
         DataFrame containing dates, teams, and scores for each matchup.
     """
+    # Setting a proper User-Agent header to respect Wikipedia's robot policy
+    headers = {
+        'User-Agent': 'sportsref-nfl/0.1.2 (https://github.com/tefirman/sportsref-nfl; tefirman@gmail.com)'
+    }
     response = requests.get(
-        "https://en.wikipedia.org/wiki/NFL_International_Series"
+        "https://en.wikipedia.org/wiki/NFL_International_Series",
+        headers=headers
     ).text
     soup = BeautifulSoup(response, "html.parser")
     tables = soup.find_all("table", attrs={"class": "wikitable sortable"})[1:-1]


### PR DESCRIPTION
## Description
- Recently saw weird behavior out of the international game data pull from Wikipedia.
- Turns out we needed to add a user-agent header to the pull to [respect Wikipedia's robot policy](https://wikitech.wikimedia.org/wiki/Robot_policy).
- Added the header, pull works as expected.
- Also fixed a minor future warning that kept popping up during usage within `fantasyfb`.

## Testing
- Tested locally within `fantasyfb`, works as expected.
- See GitHub Action checks below.